### PR TITLE
Upgrade for 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-art",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "keywords": [
     "react",
     "art",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "art": "~0.9.0",
-    "react": "0.9.0"
+    "react": "^0.10.0"
   },
   "devDependencies": {},
   "engines": {

--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Facebook, Inc.
+ * Copyright 2013-2014 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ var Transform = require('art/core/transform');
 var Mode = require('art/modes/current');
 
 var DOMPropertyOperations = require('react/lib/DOMPropertyOperations');
+var ReactBrowserComponentMixin = require('react/lib/ReactBrowserComponentMixin');
 var ReactComponent = require('react/lib/ReactComponent');
 var ReactMount = require('react/lib/ReactMount');
 var ReactMultiChild = require('react/lib/ReactMultiChild');
@@ -60,14 +61,20 @@ function createComponent(name) {
   for (var i = 1, l = arguments.length; i < l; i++) {
     mixInto(ReactARTComponent, arguments[i]);
   }
+
   var ConvenienceConstructor = function(props, children) {
     var instance = new ReactARTComponent();
     // Children can be either an array or more than one argument
     instance.construct.apply(instance, arguments);
     return instance;
   };
+
+  // Expose the convience constructor on the prototype so that it can be
+  // easily accessed on descriptors. E.g. <Foo />.type === Foo.type
+  // This for consistency with other descriptors and future proofing.
   ConvenienceConstructor.type = ReactARTComponent;
   ReactARTComponent.prototype.type = ReactARTComponent;
+
   return ConvenienceConstructor;
 }
 
@@ -186,7 +193,8 @@ var Surface = createComponent(
   'Surface',
   ReactDOMComponent.Mixin,
   ReactComponentMixin,
-  ContainerMixin, {
+  ContainerMixin,
+  ReactBrowserComponentMixin, {
 
   mountComponent: function(rootID, transaction, mountDepth) {
     ReactComponentMixin.mountComponent.call(

--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Facebook, Inc.
+ * Copyright 2013-2014 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,14 +113,14 @@ describe('ReactART', function() {
 
   it('should have the correct lifecycle state', function() {
     var instance = <TestComponent />;
-    ReactTestUtils.renderIntoDocument(instance);
+    instance = ReactTestUtils.renderIntoDocument(instance);
     var group = instance.refs.group;
     expect(group._lifeCycleState).toBe('MOUNTED');
   });
 
   it('should render a reasonable SVG structure in SVG mode', function() {
     var instance = <TestComponent />;
-    ReactTestUtils.renderIntoDocument(instance);
+    instance = ReactTestUtils.renderIntoDocument(instance);
 
     var expectedStructure = {
       nodeName: 'SVG',
@@ -151,7 +151,7 @@ describe('ReactART', function() {
 
   it('should be able to reorder components', function() {
     var instance = <TestComponent flipped={false} />;
-    ReactTestUtils.renderIntoDocument(instance);
+    instance = ReactTestUtils.renderIntoDocument(instance);
 
     var expectedStructure = {
       nodeName: 'SVG',


### PR DESCRIPTION
Bring in files at ~0.10. Not much else had really changed and this builds (probably works).

I had to leave off a feature we have that currently has too many internal dependencies, so externally we won't be supporting `ReactART.CSSBackgroundPattern` yet.
