### PR TITLE
corrected signature of mountComponent to current version

### DIFF
--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -401,7 +401,7 @@ var NodeMixin = merge(ReactComponentMixin, {
 
 var Group = createComponent('Group', NodeMixin, ContainerMixin, {
 
-  mountComponent: function(transaction) {
+  mountComponent: function(rootID, transaction, mountDepth) {
     ReactComponentMixin.mountComponent.apply(this, arguments);
     this.node = Mode.Group();
     this.applyGroupProps(BLANK_PROPS, this.props);
@@ -433,7 +433,7 @@ var Group = createComponent('Group', NodeMixin, ContainerMixin, {
 var ClippingRectangle = createComponent(
     'ClippingRectangle', NodeMixin, ContainerMixin, {
 
-  mountComponent: function(transaction) {
+  mountComponent: function(rootID, transaction, mountDepth) {
     ReactComponentMixin.mountComponent.apply(this, arguments);
     this.node = Mode.ClippingRectangle();
     this.applyClippingProps(BLANK_PROPS, this.props);


### PR DESCRIPTION
this is cherry picked from fix-for-react-changes (see pull request https://github.com/facebook/react-art/pull/20) against master (instead of 0.10-stable) for easier pull request

i do not know/understand react and art enough to come up with a reasonable test.  I just made it because observed runtime type errors are fixed with this. I got these runtime errors by using react-art from om so i'm not sure i can provide a minimal testcase. The fix is purely based on symmetry with other mountComponent function signatures in ReactART.js.
