### PR TITLE
Add test for lifecycle methods in <Group/> child

### DIFF
--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -193,4 +193,24 @@ describe('ReactART', function() {
     testDOMNodeStructure(realNode, expectedNewStructure);
   });
 
+  it('renders composite with lifecycle inside group', function() {
+    var mounted = false;
+    var CustomShape = React.createClass({
+      render: function() {
+        return <Shape />;
+      },
+      componentDidMount: function() {
+        mounted = true;
+      }
+    });
+    ReactTestUtils.renderIntoDocument(
+      <Surface>
+        <Group>
+          <CustomShape />
+        </Group>
+      </Surface>
+    );
+    expect(mounted).toBe(true);
+  });
+
 });


### PR DESCRIPTION
This test fails before https://github.com/facebook/react-art/pull/21 and passes after.

Test Plan: jest before and after applying facebook/react-art#21.
