### PR TITLE
Update for compatibility with React master

### DIFF
--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -107,7 +107,8 @@ describe('ReactART', function() {
     var instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     var group = instance.refs.group;
-    expect(group._lifeCycleState).toBe('MOUNTED');
+    // Duck type test for an ART group
+    expect(typeof group.indicate).toBe('function');
   });
 
   it('should render a reasonable SVG structure in SVG mode', function() {


### PR DESCRIPTION
- this.props -> this._currentElement.props
- set up all fields during the construct phase
- pass context through, except for the root which creates an empty context
- BLANK_PROPS -> empty object
- refs now give the underlying ART instance (could also be null?)
