### PR TITLE
Pass props.id through to the rendered Surface tag

### DIFF
--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -237,6 +237,7 @@ var Surface = React.createClass({
         accesskey={props.accesskey}
         className={props.className}
         draggable={props.draggable}
+        id={props.id}
         role={props.role}
         style={props.style}
         tabindex={props.tabindex}


### PR DESCRIPTION
This allows setting the element's id tag.

Note: I couldn't run the build or test suites - it appears gulp and jest aren't part of the package.json, and I received errors when attempting to install them.