### PR TITLE
Add gulp-styled shell script to build and publish examples website

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var gReact = require('gulp-react');
 var del = require('del');
+var shell = require('gulp-shell');
 
 gulp.task('clean', function(cb) {
   del(['lib/', 'Flux.js'], cb);
@@ -12,3 +13,14 @@ gulp.task('default', ['clean'], function() {
              .pipe(gulp.dest('lib'));
 
 });
+
+gulp.task('build-examples-website', ['clean'], shell.task([
+  'git checkout gh-pages',
+  'git merge master',
+  'cd examples/vector-widget; ../../node_modules/.bin/webpack app.js bundle.js',
+  'cp -r examples/* .',
+  'git add --all .',
+  'git commit -m "Update website"',
+  'git push origin gh-pages',
+  'git checkout master'
+]));

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "del": "^0.1.3",
     "gulp": "^3.8.10",
     "gulp-react": "^2.0.0",
+    "gulp-shell": "^0.3.0",
     "jest-cli": "^0.2.1",
     "react": "^0.13.0-beta.1",
-    "react-tools": "^0.13.0-beta.1"
+    "react-tools": "^0.13.0-beta.1",
+    "webpack": "^1.5.3"
   },
   "scripts": {
     "prepublish": "./node_modules/.bin/gulp",


### PR DESCRIPTION
Fixes #39 

Running `gulp build-examples-website` produced http://kyleamathews.github.io/react-art/vector-widget/