### PR TITLE
Update devDeps to use react@0.14. Add fbjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "url": "https://github.com/reactjs/react-art.git"
   },
   "dependencies": {
-    "art": "^0.10.0"
+    "art": "^0.10.0",
+    "fbjs": "^0.2.0"
   },
   "peerDependencies": {
     "react": "^0.13.0 || ^0.14.0-a"
@@ -29,7 +30,7 @@
     "gulp-react": "^2.0.0",
     "gulp-shell": "^0.3.0",
     "jest-cli": "^0.2.1",
-    "react": "^0.13.0",
+    "react": "^0.14.0-a",
     "react-tools": "^0.13.0"
   },
   "scripts": {

--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -22,7 +22,7 @@ var ReactMultiChild = require('react/lib/ReactMultiChild');
 var ReactUpdates = require('react/lib/ReactUpdates');
 
 var assign = require('react/lib/Object.assign');
-var emptyObject = require('react/lib/emptyObject');
+var emptyObject = require('fbjs/lib/emptyObject');
 
 var pooledTransform = new Transform();
 


### PR DESCRIPTION
Importing `emptyObject` from `fbjs` fixes the tests when using `react@0.14`, but I'm happy to discuss other solutions.

Fixes #58 

Running `npm test` gives the following warnings which I might have a look at fixing:
```
Warning: Surface.getDOMNode(...) is deprecated. Please use React.findDOMNode(instance) instead.
Warning: TestComponent.getDOMNode(...) is deprecated. Please use React.findDOMNode(instance) instead.
Warning: setProps(...) and replaceProps(...) are deprecated. Instead, call React.render again at the top level.
Warning: `require("react").render` is deprecated. Please use `require("react-dom").render` instead.
```