### PR TITLE
Remove deprecated warnings in tests by updating to react-dom etc

### DIFF
--- a/examples/vector-widget/package.json
+++ b/examples/vector-widget/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "jsx-loader": "~0.12.0",
-    "react": "^0.13.0",
+    "react": "^0.14.0-a",
     "webpack": "~1.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-shell": "^0.3.0",
     "jest-cli": "^0.2.1",
     "react": "^0.14.0-a",
+    "react-dom": "^0.14.0-a",
     "react-tools": "^0.13.0"
   },
   "scripts": {

--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -186,9 +186,8 @@ var Surface = React.createClass({
   mixins: [ContainerMixin],
 
   componentDidMount: function() {
-    var domNode = this.getDOMNode();
 
-    this.node = Mode.Surface(+this.props.width, +this.props.height, domNode);
+    this.node = Mode.Surface(+this.props.width, +this.props.height, this.domNode);
 
     var transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
     transaction.perform(
@@ -237,6 +236,7 @@ var Surface = React.createClass({
     // TODO: ART's Canvas Mode overrides surface title and cursor
     return (
       <Mode.Surface.tagName
+        ref={c => this.domNode = c}
         accesskey={props.accesskey}
         className={props.className}
         draggable={props.draggable}

--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -18,6 +18,7 @@ require('mock-modules')
 
 var React;
 var ReactTestUtils;
+var ReactDOM;
 
 var Group;
 var Shape;
@@ -51,6 +52,7 @@ describe('ReactART', function() {
   beforeEach(function() {
     React = require('react');
     ReactTestUtils = require('react/lib/ReactTestUtils');
+    ReactDOM = require('react-dom');
 
     var ReactART = require('ReactART');
     var ARTSVGMode = require('art/modes/svg');
@@ -138,13 +140,13 @@ describe('ReactART', function() {
       ]
     };
 
-    var realNode = instance.getDOMNode();
+    var realNode = ReactDOM.findDOMNode(instance);
     testDOMNodeStructure(realNode, expectedStructure);
   });
 
   it('should be able to reorder components', function() {
-    var instance = <TestComponent flipped={false} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    var container = document.createElement('div');
+    var instance = ReactDOM.render(<TestComponent flipped={false} />, container);
 
     var expectedStructure = {
       nodeName: 'SVG',
@@ -162,10 +164,10 @@ describe('ReactART', function() {
       ]
     };
 
-    var realNode = instance.getDOMNode();
+    var realNode = ReactDOM.findDOMNode(instance);
     testDOMNodeStructure(realNode, expectedStructure);
 
-    instance.setProps({ flipped: true });
+    ReactDOM.render(<TestComponent flipped={true} />, container);
 
     var expectedNewStructure = {
       nodeName: 'SVG',
@@ -256,9 +258,9 @@ describe('ReactART', function() {
       }
     });
     var container = document.createElement('div');
-    React.render(<Outer />, container);
+    ReactDOM.render(<Outer />, container);
     expect(ref).not.toBeDefined();
-    React.render(<Outer mountCustomShape={true} />, container);
+    ReactDOM.render(<Outer mountCustomShape={true} />, container);
     expect(ref.constructor).toBe(CustomShape);
   });
 


### PR DESCRIPTION
Any reason I'm not aware of why I should put `react-dom` as a peerDependency instead?

There's one more warning I haven't removed, resulting from usage of `setProps` [here](https://github.com/ThomWright/react-art/blob/6e7d6543669de40b06a56a654fb62b604570d11d/src/__tests__/ReactART-test.js#L170).

I'm not familiar with using React in this way so I'm not sure what the appropriate refactoring would be. The message says `call React.render again at the top level` - not sure how to do this in this case! Give me a hint and I'll add it to the commit :wink: 

Other than that, the deprecation messages were very helpful, which is great.