### PR TITLE
Sync out changes from FB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
+  - 4

--- a/jest/environment.js
+++ b/jest/environment.js
@@ -1,1 +1,1 @@
-__DEV__ = true;
+global.__DEV__ = true;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/reactjs/react-art.git"
   },
   "dependencies": {
-    "art": "^0.10.0",
+    "art": "^0.10.1",
     "fbjs": "^0.2.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "gulp-react": "^2.0.0",
     "gulp-shell": "^0.3.0",
     "jest-cli": "^0.8.2",
-    "react": "^0.14.5",
+    "react": "http://react.zpao.com/builds/master/latest/react.tgz",
     "react-addons-test-utils": "^0.14.5",
-    "react-dom": "^0.14.5"
+    "react-dom": "http://react.zpao.com/builds/master/latest/react-dom.tgz"
   },
   "scripts": {
     "prepublish": "gulp",

--- a/package.json
+++ b/package.json
@@ -30,16 +30,14 @@
     "gulp": "^3.8.10",
     "gulp-react": "^2.0.0",
     "gulp-shell": "^0.3.0",
-    "jest-cli": "^0.2.1",
-    "react": "^0.14.0-a",
-    "react-dom": "^0.14.0-a"
+    "jest-cli": "^0.8.2",
+    "react": "^0.14.5",
+    "react-addons-test-utils": "^0.14.5",
+    "react-dom": "^0.14.5"
   },
   "scripts": {
     "prepublish": "gulp",
     "test": "jest"
-  },
-  "engines": {
-    "node": ">=0.10.0"
   },
   "jest": {
     "rootDir": "src",

--- a/src/Circle.art.js
+++ b/src/Circle.art.js
@@ -22,18 +22,17 @@
 var React = require('react');
 var ReactART = require('./ReactART');
 
-var Props = React.PropTypes;
-var Shape = ReactART.Shape;
+var {PropTypes} = React;
 var Path = ReactART.Path;
+var Shape = ReactART.Shape;
 
 /**
  * Circle is a React component for drawing circles. Like other ReactART
  * components, it must be used in a <Surface>.
  */
 var Circle = React.createClass({
-
   propTypes: {
-    radius: Props.number.isRequired
+    radius: PropTypes.number.isRequired,
   },
 
   render: function() {
@@ -44,8 +43,7 @@ var Circle = React.createClass({
         .arc(0, radius * -2, radius)
         .close();
     return <Shape {...this.props} d={path} />;
-  }
-
+  },
 });
 
 module.exports = Circle;

--- a/src/Rectangle.art.js
+++ b/src/Rectangle.art.js
@@ -29,7 +29,7 @@
 var React = require('react');
 var ReactART = require('./ReactART');
 
-var Props = React.PropTypes;
+var {PropTypes} = React;
 var Shape = ReactART.Shape;
 var Path = ReactART.Path;
 
@@ -38,15 +38,14 @@ var Path = ReactART.Path;
  * components, it must be used in a <Surface>.
  */
 var Rectangle = React.createClass({
-
   propTypes: {
-    width: Props.number.isRequired,
-    height: Props.number.isRequired,
-    radius: Props.number,
-    radiusTopLeft: Props.number,
-    radiusTopRight: Props.number,
-    radiusBottomRight: Props.number,
-    radiusBottomLeft: Props.number
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    radius: PropTypes.number,
+    radiusTopLeft: PropTypes.number,
+    radiusTopRight: PropTypes.number,
+    radiusBottomRight: PropTypes.number,
+    radiusBottomLeft: PropTypes.number,
   },
 
   render: function() {

--- a/src/Wedge.art.js
+++ b/src/Wedge.art.js
@@ -25,7 +25,7 @@
 var React = require('react');
 var ReactART = require('./ReactART');
 
-var Props = React.PropTypes;
+var {PropTypes} = React;
 var Shape = ReactART.Shape;
 var Path = ReactART.Path;
 
@@ -36,10 +36,10 @@ var Path = ReactART.Path;
 var Wedge = React.createClass({
 
   propTypes: {
-    outerRadius: Props.number.isRequired,
-    startAngle: Props.number.isRequired,
-    endAngle: Props.number.isRequired,
-    innerRadius: Props.number
+    outerRadius: PropTypes.number.isRequired,
+    startAngle: PropTypes.number.isRequired,
+    endAngle: PropTypes.number.isRequired,
+    innerRadius: PropTypes.number
   },
 
   circleRadians: Math.PI * 2,

--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -11,14 +11,14 @@
 
 /*jslint evil: true */
 
-"use strict";
+'use strict';
 
-require('mock-modules')
+jest
   .dontMock('ReactART');
 
-var React;
-var ReactTestUtils;
-var ReactDOM;
+var React = require('react');
+var ReactDOM = require('react-dom');
+var ReactTestUtils = require('react-addons-test-utils');
 
 var Group;
 var Shape;
@@ -26,6 +26,10 @@ var Surface;
 var TestComponent;
 
 var Missing = {};
+
+var ReactART = require('ReactART');
+var ARTSVGMode = require('art/modes/svg');
+var ARTCurrentMode = require('art/modes/current');
 
 function testDOMNodeStructure(domNode, expectedStructure) {
   expect(domNode).toBeDefined();
@@ -50,14 +54,6 @@ function testDOMNodeStructure(domNode, expectedStructure) {
 describe('ReactART', function() {
 
   beforeEach(function() {
-    React = require('react');
-    ReactTestUtils = require('react/lib/ReactTestUtils');
-    ReactDOM = require('react-dom');
-
-    var ReactART = require('ReactART');
-    var ARTSVGMode = require('art/modes/svg');
-    var ARTCurrentMode = require('art/modes/current');
-
     ARTCurrentMode.setCurrent(ARTSVGMode);
 
     Group = ReactART.Group;
@@ -65,7 +61,6 @@ describe('ReactART', function() {
     Surface = ReactART.Surface;
 
     TestComponent = React.createClass({
-
       render: function() {
 
         var a =
@@ -102,7 +97,6 @@ describe('ReactART', function() {
         );
       }
     });
-
   });
 
   it('should have the correct lifecycle state', function() {
@@ -118,23 +112,23 @@ describe('ReactART', function() {
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     var expectedStructure = {
-      nodeName: 'SVG',
+      nodeName: 'svg',
       width: '150',
       height: '200',
       children: [
-        { nodeName: 'DEFS' },
+        { nodeName: 'defs' },
         {
-          nodeName: 'G',
+          nodeName: 'g',
           children: [
             {
-              nodeName: 'DEFS',
+              nodeName: 'defs',
               children: [
-                { nodeName: 'LINEARGRADIENT' }
+                { nodeName: 'linearGradient' }
               ]
             },
-            { nodeName: 'PATH' },
-            { nodeName: 'PATH' },
-            { nodeName: 'G' }
+            { nodeName: 'path' },
+            { nodeName: 'path' },
+            { nodeName: 'g' }
           ]
         }
       ]
@@ -149,16 +143,16 @@ describe('ReactART', function() {
     var instance = ReactDOM.render(<TestComponent flipped={false} />, container);
 
     var expectedStructure = {
-      nodeName: 'SVG',
+      nodeName: 'svg',
       children: [
-        { nodeName: 'DEFS' },
+        { nodeName: 'defs' },
         {
-          nodeName: 'G',
+          nodeName: 'g',
           children: [
-            { nodeName: 'DEFS' },
-            { nodeName: 'PATH', opacity: '0.1' },
-            { nodeName: 'PATH', opacity: Missing },
-            { nodeName: 'G' }
+            { nodeName: 'defs' },
+            { nodeName: 'path', opacity: '0.1' },
+            { nodeName: 'path', opacity: Missing },
+            { nodeName: 'g' }
           ]
         }
       ]
@@ -170,16 +164,16 @@ describe('ReactART', function() {
     ReactDOM.render(<TestComponent flipped={true} />, container);
 
     var expectedNewStructure = {
-      nodeName: 'SVG',
+      nodeName: 'svg',
       children: [
-        { nodeName: 'DEFS' },
+        { nodeName: 'defs' },
         {
-          nodeName: 'G',
+          nodeName: 'g',
           children: [
-            { nodeName: 'DEFS' },
-            { nodeName: 'PATH', opacity: Missing },
-            { nodeName: 'PATH', opacity: '0.1' },
-            { nodeName: 'G' }
+            { nodeName: 'defs' },
+            { nodeName: 'path', opacity: Missing },
+            { nodeName: 'path', opacity: '0.1' },
+            { nodeName: 'g' }
           ]
         }
       ]


### PR DESCRIPTION
This bring out the latest from FB and also upgrades the build so it should work with node 4.

Problem: the changes we've made internally depend on unreleased changes to React - we haven't published the current alphas to npm. So instead I've pointed at the latest packages that are a part of the "latest" build on my server. This works (ignoring the failing peer dependency) but obviously isn't something releasable. That's probably ok since I suspect we won't ship a new version with any substantial changes until the next version of React anyway.