### PR TITLE
Use default props

### DIFF
--- a/src/Rectangle.art.js
+++ b/src/Rectangle.art.js
@@ -47,11 +47,17 @@ var Rectangle = React.createClass({
     radiusBottomRight: PropTypes.number,
     radiusBottomLeft: PropTypes.number,
   },
+  
+  getDefaultProps: function() {
+    return {
+      radius: 0
+    };
+  },
 
   render: function() {
     var width = this.props.width;
     var height = this.props.height;
-    var radius = this.props.radius ? this.props.radius : 0;
+    var radius = this.props.radius;
 
     // if unspecified, radius(Top|Bottom)(Left|Right) defaults to the radius
     // property


### PR DESCRIPTION
We could use `getDefaultProps` instead of a ternary expression inside render function body.