### PR TITLE
Require reconciler code from ReactDOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "gulp-babel": "^6.1.2",
     "gulp-shell": "^0.5.2",
     "jest-cli": "^12.0.2",
-    "react": "^15.0.2",
+    "react": "^15.4.0",
     "react-addons-test-utils": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "react-dom": "^15.4.0"
   },
   "scripts": {
     "prepublish": "gulp",

--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -20,9 +20,9 @@ const Mode = require('art/modes/current');
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const ReactInstanceMap = require('react/lib/ReactInstanceMap');
-const ReactMultiChild = require('react/lib/ReactMultiChild');
-const ReactUpdates = require('react/lib/ReactUpdates');
+const ReactInstanceMap = require('react-dom/lib/ReactInstanceMap');
+const ReactMultiChild = require('react-dom/lib/ReactMultiChild');
+const ReactUpdates = require('react-dom/lib/ReactUpdates');
 
 const emptyObject = require('fbjs/lib/emptyObject');
 const invariant = require('fbjs/lib/invariant');


### PR DESCRIPTION
As pointed in https://github.com/facebook/react/issues/7770#issuecomment-253899837, some internal modules of React 15.4.0 will be moved to react-dom package. When this happens, React ART will have to require `ReactInstanceMap`, `ReactMultiChild`, `ReactUpdates` from react-dom instead of react.

Fixes #103.

**Note for maintainers:** Before merging this, you might want to revert https://github.com/reactjs/react-art/commit/db4dcef9532cc9e3e1235bc62e917efcb3fb5b24, since it's purpose is delayed until React 16 (https://github.com/facebook/react/pull/7598). This is the reason why tests are failing right now.

:dancer: 
