### PR TITLE
Fixed event handler update bug in (non-fiber/legacy) ReactART

### DIFF
--- a/src/ReactART.js
+++ b/src/ReactART.js
@@ -20,9 +20,9 @@ const Mode = require('art/modes/current');
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const ReactInstanceMap = require('react/lib/ReactInstanceMap');
-const ReactMultiChild = require('react/lib/ReactMultiChild');
-const ReactUpdates = require('react/lib/ReactUpdates');
+const ReactInstanceMap = require('react-dom/lib/ReactInstanceMap');
+const ReactMultiChild = require('react-dom/lib/ReactMultiChild');
+const ReactUpdates = require('react-dom/lib/ReactUpdates');
 
 const emptyObject = require('fbjs/lib/emptyObject');
 const invariant = require('fbjs/lib/invariant');
@@ -93,7 +93,7 @@ function injectAfter(parentNode, referenceNode, node) {
 
 // ContainerMixin for components that can hold ART nodes
 
-const ContainerMixin = assign({}, ReactMultiChild, {
+const ContainerMixin = assign({}, ReactMultiChild.Mixin, {
 
   /**
    * Moves a child component to the supplied index.
@@ -278,7 +278,7 @@ const NodeMixin = {
     listeners[type] = listener;
     if (listener) {
       if (!subscriptions[type]) {
-        subscriptions[type] = this.node.subscribe(type, listener, this);
+        subscriptions[type] = this.node.subscribe(type, this.handleEvent, this);
       }
     } else {
       if (subscriptions[type]) {

--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -286,4 +286,33 @@ describe('ReactART', function() {
     expect(ref.constructor).toBe(CustomShape);
   });
 
+  it('adds and updates event handlers', function() {
+    const container = document.createElement('div');
+
+    function render(onClick) {
+      return ReactDOM.render(
+        <Surface>
+          <Shape onClick={onClick} />
+        </Surface>,
+        container,
+      );
+    }
+
+    function doClick(instance) {
+      const path = ReactDOM.findDOMNode(instance).querySelector('path');
+
+      // ReactTestUtils.Simulate.click doesn't work with SVG elements
+      path.click();
+    }
+
+    const onClick1 = jest.fn();
+    let instance = render(onClick1);
+    doClick(instance);
+    expect(onClick1).toBeCalled();
+
+    const onClick2 = jest.fn();
+    instance = render(onClick2);
+    doClick(instance);
+    expect(onClick2).toBeCalled();
+  });
 });


### PR DESCRIPTION
[This line](https://github.com/reactjs/react-art/blob/db4dcef9532cc9e3e1235bc62e917efcb3fb5b24/src/ReactART.js#L281) in `ReactART` causes a bug that will ignore updated event handlers for a given event type once set (eg if you set `onClick={handler1}` and then later set `onClick={handler2}`, the first handler will continue to receive events).

This PR fixes that issue by using the intended `handleEvent ` proxy method.. I've added unit test coverage as well.

Note that this PR partially overlaps with PR #105 since I had to patch the imports (eg `react/lib` to `react-dom/lib`) and multi-child mixin (eg `ReactMultiChild` to `ReactMultiChild.Mixin`).