### PR TITLE
Sync changes to ReactART from main React repo

### DIFF
--- a/src/ReactARTFiber.js
+++ b/src/ReactARTFiber.js
@@ -388,6 +388,10 @@ class Surface extends Component {
 
 const ARTRenderer = ReactFiberReconciler({
   appendChild(parentInstance, child) {
+    if (child.parentNode === parentInstance) {
+      child.eject();
+    }
+
     child.inject(parentInstance);
   },
 
@@ -451,6 +455,11 @@ const ARTRenderer = ReactFiberReconciler({
   },
 
   insertBefore(parentInstance, child, beforeChild) {
+    invariant(
+      child !== beforeChild,
+      'ReactART: Can not insert node before itself'
+    );
+
     child.injectBefore(beforeChild);
   },
 
@@ -472,9 +481,20 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
+  resetTextContent(domElement) {
+    // Noop
+  },
+
   scheduleAnimationCallback: window.requestAnimationFrame,
 
   scheduleDeferredCallback: window.requestIdleCallback,
+
+  shouldSetTextContent(props) {
+    return (
+      typeof props.children === 'string' ||
+      typeof props.children === 'number'
+    );
+  },
 
   useSyncScheduling: true,
 });

--- a/src/ReactARTFiber.js
+++ b/src/ReactARTFiber.js
@@ -454,6 +454,10 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
+  getChildHostContext() {
+    return null;
+  },
+
   insertBefore(parentInstance, child, beforeChild) {
     invariant(
       child !== beforeChild,

--- a/src/__tests__/ReactART-test.js
+++ b/src/__tests__/ReactART-test.js
@@ -51,17 +51,17 @@ function testDOMNodeStructure(domNode, expectedStructure) {
   }
 }
 
-describe('ReactART', function() {
+describe('ReactART', () => {
 
-  beforeEach(function() {
+  beforeEach(() => {
     ARTCurrentMode.setCurrent(ARTSVGMode);
 
     Group = ReactART.Group;
     Shape = ReactART.Shape;
     Surface = ReactART.Surface;
 
-    TestComponent = React.createClass({
-      render: function() {
+    TestComponent = class extends React.Component {
+      render() {
 
         var a =
           <Shape
@@ -96,10 +96,10 @@ describe('ReactART', function() {
           </Surface>
         );
       }
-    });
+    };
   });
 
-  it('should have the correct lifecycle state', function() {
+  it('should have the correct lifecycle state', () => {
     var instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     var group = instance.refs.group;
@@ -107,7 +107,7 @@ describe('ReactART', function() {
     expect(typeof group.indicate).toBe('function');
   });
 
-  it('should render a reasonable SVG structure in SVG mode', function() {
+  it('should render a reasonable SVG structure in SVG mode', () => {
     var instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -138,7 +138,7 @@ describe('ReactART', function() {
     testDOMNodeStructure(realNode, expectedStructure);
   });
 
-  it('should be able to reorder components', function() {
+  it('should be able to reorder components', () => {
     var container = document.createElement('div');
     var instance = ReactDOM.render(<TestComponent flipped={false} />, container);
 
@@ -182,19 +182,19 @@ describe('ReactART', function() {
     testDOMNodeStructure(realNode, expectedNewStructure);
   });
 
-  it('should be able to reorder many components', function() {
+  it('should be able to reorder many components', () => {
     var container = document.createElement('div');
 
-    var Component = React.createClass({
-      render: function() {
+    class Component extends React.Component {
+      render() {
         var chars = this.props.chars.split('');
         return (
           <Surface>
             {chars.map((text) => <Shape key={text} title={text} />)}
           </Surface>
         );
-      },
-    });
+      }
+    }
 
     // Mini multi-child stress test: lots of reorders, some adds, some removes.
     var before = 'abcdefghijklmnopqrst';
@@ -210,16 +210,19 @@ describe('ReactART', function() {
     ReactDOM.unmountComponentAtNode(container);
   });
 
-  it('renders composite with lifecycle inside group', function() {
+  it('renders composite with lifecycle inside group', () => {
     var mounted = false;
-    var CustomShape = React.createClass({
-      render: function() {
+
+    class CustomShape extends React.Component {
+      render() {
         return <Shape />;
-      },
-      componentDidMount: function() {
+      }
+
+      componentDidMount() {
         mounted = true;
       }
-    });
+    }
+
     ReactTestUtils.renderIntoDocument(
       <Surface>
         <Group>
@@ -230,18 +233,21 @@ describe('ReactART', function() {
     expect(mounted).toBe(true);
   });
 
-  it('resolves refs before componentDidMount', function() {
-    var CustomShape = React.createClass({
-      render: function() {
+  it('resolves refs before componentDidMount', () => {
+    class CustomShape extends React.Component {
+      render() {
         return <Shape />;
       }
-    });
+    }
+
     var ref = null;
-    var Outer = React.createClass({
-      componentDidMount: function() {
+
+    class Outer extends React.Component {
+      componentDidMount() {
         ref = this.refs.test;
-      },
-      render: function() {
+      }
+
+      render() {
         return (
           <Surface>
             <Group>
@@ -250,26 +256,31 @@ describe('ReactART', function() {
           </Surface>
         );
       }
-    });
+    }
+
     ReactTestUtils.renderIntoDocument(<Outer />);
     expect(ref.constructor).toBe(CustomShape);
   });
 
-  it('resolves refs before componentDidUpdate', function() {
-    var CustomShape = React.createClass({
-      render: function() {
+  it('resolves refs before componentDidUpdate', () => {
+    class CustomShape extends React.Component {
+      render() {
         return <Shape />;
       }
-    });
+    }
+
     var ref = {};
-    var Outer = React.createClass({
-      componentDidMount: function() {
+
+    class Outer extends React.Component {
+      componentDidMount() {
         ref = this.refs.test;
-      },
-      componentDidUpdate: function() {
+      }
+
+      componentDidUpdate() {
         ref = this.refs.test;
-      },
-      render: function() {
+      }
+
+      render() {
         return (
           <Surface>
             <Group>
@@ -278,7 +289,8 @@ describe('ReactART', function() {
           </Surface>
         );
       }
-    });
+    }
+
     var container = document.createElement('div');
     ReactDOM.render(<Outer />, container);
     expect(ref).not.toBeDefined();
@@ -286,7 +298,7 @@ describe('ReactART', function() {
     expect(ref.constructor).toBe(CustomShape);
   });
 
-  it('adds and updates event handlers', function() {
+  it('adds and updates event handlers', () => {
     const container = document.createElement('div');
 
     function render(onClick) {


### PR DESCRIPTION
These changes primarily include the new Fiber `HostConfig` methods `shouldSetTextContent` and `resetTextContent`.

Minor test formatting changes were copied over as well to simplify the process of keeping both repos in sync going forward. (No new tests were added in this change set.)

Synced from facebook/react/pull/8521.