### PR TITLE
Link to new location of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***Note**: This package is now part of the [facebook/react](https://github.com/facebook/react/tree/master/packages/react-art) monorepo.*
+
 # React ART
 
 React ART is a JavaScript library for drawing vector graphics using [React](http://facebook.github.io/react/).


### PR DESCRIPTION
 This repository shows up in web searches for `react-art` and is misleading.